### PR TITLE
Add Example

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,12 @@ jobs:
       - name: Build targets
         run: cmake --build build
 
+      - name: Reconfigure CMake to build the examples
+        run: cmake . -B build -DBUILD_EXAMPLE=ON
+
+      - name: Rebuild targets
+        run: cmake --build build
+
   test:
     runs-on: windows-latest
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,8 @@ else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wshadow -Wnon-virtual-dtor -Wpedantic")
 endif()
 
+option(BUILD_EXAMPLE "build the examples" OFF)
+
 include(cmake/CPM.cmake)
 cpmaddpackage("gh:TheLartians/Format.cmake@1.7.3")
 cpmaddpackage(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,3 +40,7 @@ if(BUILD_TESTING)
   target_link_libraries(volume_test PRIVATE volume Catch2::Catch2WithMain)
   catch_discover_tests(volume_test)
 endif()
+
+if(BUILD_EXAMPLE)
+  add_subdirectory(examples)
+endif()

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Alfi Maulana
+Copyright (c) 2022-2023 Alfi Maulana
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_executable(volume_count_devices count_devices.cpp)
+target_link_libraries(volume_count_devices PRIVATE volume)

--- a/examples/count_devices.cpp
+++ b/examples/count_devices.cpp
@@ -1,0 +1,18 @@
+#include <volume/device.hpp>
+#include <iostream>
+
+int main() {
+  const auto inputs = vol::list_input_devices();
+  if (inputs.is_err()) {
+    std::cerr << "failed to list input devices! " << inputs.unwrap_err() << std::endl;
+    return 1;
+  }
+  const auto outputs = vol::list_output_devices();
+  if (outputs.is_err()) {
+    std::cerr << "failed to list output devices! " << outputs.unwrap_err() << std::endl;
+    return 1;
+  }
+  std::cout << "input devices: " << inputs.unwrap().size() << std::endl;
+  std::cout << "output devices: " << outputs.unwrap().size() << std::endl;
+  return 0;
+}


### PR DESCRIPTION
- Add example main for this project, currently with the following example:
  - Count input and output volume device.
- Build example if `BUILD_EXAMPLE` option is set to be `ON`.
- Build example in `build.yml` workflow under `release` job.