### PR TITLE
Bump Result

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ cpmaddpackage("gh:TheLartians/Format.cmake@1.7.3")
 cpmaddpackage(
   NAME result
   GITHUB_REPOSITORY threeal/result
-  GIT_TAG 7acc062
+  GIT_TAG ab4b3c1
   OPTIONS "BUILD_TESTING OFF")
 
 if(WIN32)

--- a/include/volume/device.hpp
+++ b/include/volume/device.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <result/result_or.hpp>
+#include <result/result_of.hpp>
 #include <string>
 #include <vector>
 
@@ -10,7 +10,7 @@ struct Device {};
 
 using Devices = std::vector<Device>;
 
-res::ResultOr<Devices> list_input_devices();
-res::ResultOr<Devices> list_output_devices();
+res::ResultOf<Devices> list_input_devices();
+res::ResultOf<Devices> list_output_devices();
 
 }  // namespace vol

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -4,11 +4,11 @@ namespace vol {
 
 #ifndef _WIN32
 
-res::ResultOr<Devices> list_input_devices() {
+res::ResultOf<Devices> list_input_devices() {
   return res::Err("unimplemented");  //
 }
 
-res::ResultOr<Devices> list_output_devices() {
+res::ResultOf<Devices> list_output_devices() {
   return res::Err("unimplemented");  //
 }
 

--- a/src/device_windows.cpp
+++ b/src/device_windows.cpp
@@ -6,7 +6,7 @@ namespace vol {
 
 namespace {
 
-res::ResultOr<Devices> to_devices(win::DeviceCollection& win_devices) {
+res::ResultOf<Devices> to_devices(win::DeviceCollection& win_devices) {
   auto count = win_devices.count();
   if (!count.is_ok()) {
     return res::Err("failed to count devices");
@@ -22,7 +22,7 @@ res::ResultOr<Devices> to_devices(win::DeviceCollection& win_devices) {
 
 }  // namespace
 
-res::ResultOr<Devices> list_input_devices() {
+res::ResultOf<Devices> list_input_devices() {
   auto win_com = win::com_init();
   if (!win_com.is_ok()) {
     return res::Err("failed to initialize COM");
@@ -38,7 +38,7 @@ res::ResultOr<Devices> list_input_devices() {
   return to_devices(win_devices);
 }
 
-res::ResultOr<Devices> list_output_devices() {
+res::ResultOf<Devices> list_output_devices() {
   auto win_com = win::com_init();
   if (!win_com.is_ok()) {
     return res::Err("failed to initialize COM");


### PR DESCRIPTION
Bump [threeal/result](https://github.com/threeal/result) to the latest version (commit `ab4b3c1`) which replace `res::ResultOr` with `res::ResultOf`.