### PR TITLE
Separate Build and Test Workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,10 +6,8 @@ jobs:
   release:
     runs-on: windows-latest
     steps:
-      - name: Checkout this repository
-        uses: actions/checkout@v2.5.0
-        with:
-          fetch-depth: 0
+      - name: Checkout repository
+        uses: actions/checkout@v3.2.0
 
       - name: Configure CMake
         run: cmake . -B build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,9 @@
-name: build
+name: test
 on:
   workflow_dispatch:
   push:
 jobs:
-  release:
+  unit-tests:
     runs-on: windows-latest
     steps:
       - name: Checkout this repository
@@ -12,13 +12,10 @@ jobs:
           fetch-depth: 0
 
       - name: Configure CMake
-        run: cmake . -B build
+        run: cmake . -B build -DBUILD_TESTING=ON -DCMAKE_CXX_FLAGS='/WX'
 
       - name: Build targets
         run: cmake --build build
 
-      - name: Reconfigure CMake to build the examples
-        run: cmake . -B build -DBUILD_EXAMPLE=ON
-
-      - name: Rebuild targets
-        run: cmake --build build
+      - name: Run tests
+        run: ctest --test-dir build --verbose

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,22 @@ jobs:
         uses: actions/checkout@v3.2.0
 
       - name: Configure CMake
-        run: cmake . -B build -DBUILD_TESTING=ON -DCMAKE_CXX_FLAGS='/WX'
+        run: cmake . -B build -DBUILD_TESTING=ON
 
       - name: Build targets
         run: cmake --build build
 
       - name: Run tests
         run: ctest --test-dir build --verbose
+
+  check-warning:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3.2.0
+
+      - name: Configure CMake
+        run: cmake . -B build -DCMAKE_CXX_FLAGS='/WX' -DBUILD_TESTING=ON
+
+      - name: Build targets
+        run: cmake --build build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,10 +6,8 @@ jobs:
   unit-tests:
     runs-on: windows-latest
     steps:
-      - name: Checkout this repository
-        uses: actions/checkout@v2.5.0
-        with:
-          fetch-depth: 0
+      - name: Checkout repository
+        uses: actions/checkout@v3.2.0
 
       - name: Configure CMake
         run: cmake . -B build -DBUILD_TESTING=ON -DCMAKE_CXX_FLAGS='/WX'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Volume C++
 
 [![build status](https://img.shields.io/github/actions/workflow/status/threeal/volume-cpp/build.yml?branch=main)](https://github.com/threeal/volume-cpp/actions/workflows/build.yml)
+[![test status](https://img.shields.io/github/actions/workflow/status/threeal/volume-cpp/test.yml?label=test&branch=main)](https://github.com/threeal/volume-cpp/actions/workflows/test.yml)
 
 A cross-platform audio volume control library in C++.


### PR DESCRIPTION
- Separate `test` job in the `build.yml` workflow to be several jobs in the `test.yml` workflow:
  - `unit-tests` job, build and run unit tests.
  - `check-warning` job, treat warnings as errors during build.
- Bump [Checkout action](https://github.com/marketplace/actions/checkout) to the latest version.
  - Remove `fetch-depth` input when using Checkout action.
- Add test status badge in the `README.md`.