### PR TITLE
Core Windows Compile Into Static Lib

### DIFF
--- a/core/windows/CMakeLists.txt
+++ b/core/windows/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_library(volume_core_windows STATIC src/com.cpp src/device_collection.cpp src/device_enumerator.cpp)
+add_library(volume_core_windows STATIC src/com.cpp src/device_collection.cpp src/device_enumerator.cpp src/device.cpp)
 target_include_directories(volume_core_windows PUBLIC include)

--- a/core/windows/CMakeLists.txt
+++ b/core/windows/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_library(volume_core_windows STATIC src/com.cpp src/device_enumerator.cpp)
+add_library(volume_core_windows STATIC src/com.cpp src/device_collection.cpp src/device_enumerator.cpp)
 target_include_directories(volume_core_windows PUBLIC include)

--- a/core/windows/CMakeLists.txt
+++ b/core/windows/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_library(volume_core_windows INTERFACE)
-target_include_directories(volume_core_windows INTERFACE include)
+add_library(volume_core_windows STATIC src/com.cpp)
+target_include_directories(volume_core_windows PUBLIC include)

--- a/core/windows/CMakeLists.txt
+++ b/core/windows/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_library(volume_core_windows STATIC src/com.cpp)
+add_library(volume_core_windows STATIC src/com.cpp src/device_enumerator.cpp)
 target_include_directories(volume_core_windows PUBLIC include)

--- a/core/windows/include/volume/core/windows/com.hpp
+++ b/core/windows/include/volume/core/windows/com.hpp
@@ -1,30 +1,15 @@
 #pragma once
 
-#include <Objbase.h>
-#include <mmdeviceapi.h>
-
 #include "device_enumerator.hpp"
 #include "status.hpp"
 
 namespace vol::win {
 
 struct Com : public Status {
-  ~Com() {
-    if (is_ok()) CoUninitialize();
-  }
-
-  DeviceEnumerator create_device_enumerator() {
-    DeviceEnumerator res;
-    res.hr = CoCreateInstance(__uuidof(MMDeviceEnumerator), NULL, CLSCTX_ALL,
-                              __uuidof(IMMDeviceEnumerator), (void**)&res.p);
-    return res;
-  }
+  ~Com();
+  DeviceEnumerator create_device_enumerator();
 };
 
-Com com_init() {
-  Com res;
-  res.hr = CoInitialize(NULL);
-  return res;
-}
+Com com_init();
 
 }  // namespace vol::win

--- a/core/windows/include/volume/core/windows/device.hpp
+++ b/core/windows/include/volume/core/windows/device.hpp
@@ -8,10 +8,7 @@ namespace vol::win {
 
 struct Device : public Status {
   IMMDevice* p;
-
-  ~Device() {
-    if (is_ok()) p->Release();
-  }
+  ~Device();
 };
 
 }  // namespace vol::win

--- a/core/windows/include/volume/core/windows/device_collection.hpp
+++ b/core/windows/include/volume/core/windows/device_collection.hpp
@@ -10,21 +10,10 @@ namespace vol::win {
 struct DeviceCollection : public Status {
   IMMDeviceCollection* p;
 
-  ~DeviceCollection() {
-    if (is_ok()) p->Release();
-  }
+  ~DeviceCollection();
 
-  StatusOf<UINT> count() {
-    StatusOf<UINT> res;
-    res.hr = p->GetCount(&res.val);
-    return res;
-  }
-
-  Device get(UINT id) {
-    Device res;
-    res.hr = p->Item(id, &res.p);
-    return res;
-  }
+  StatusOf<UINT> count();
+  Device get(UINT id);
 };
 
 }  // namespace vol::win

--- a/core/windows/include/volume/core/windows/device_enumerator.hpp
+++ b/core/windows/include/volume/core/windows/device_enumerator.hpp
@@ -10,21 +10,10 @@ namespace vol::win {
 struct DeviceEnumerator : public Status {
   IMMDeviceEnumerator* p;
 
-  ~DeviceEnumerator() {
-    if (is_ok()) p->Release();
-  }
+  ~DeviceEnumerator();
 
-  DeviceCollection enumerate_input_devices() {
-    DeviceCollection res;
-    res.hr = p->EnumAudioEndpoints(eCapture, DEVICE_STATE_ACTIVE, &res.p);
-    return res;
-  }
-
-  DeviceCollection enumerate_output_devices() {
-    DeviceCollection res;
-    res.hr = p->EnumAudioEndpoints(eRender, DEVICE_STATE_ACTIVE, &res.p);
-    return res;
-  }
+  DeviceCollection enumerate_input_devices();
+  DeviceCollection enumerate_output_devices();
 };
 
 }  // namespace vol::win

--- a/core/windows/include/volume/core/windows/status.hpp
+++ b/core/windows/include/volume/core/windows/status.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <mmdeviceapi.h>
+#include <Winerror.h>
 
 namespace vol::win {
 

--- a/core/windows/include/volume/core/windows/status.hpp
+++ b/core/windows/include/volume/core/windows/status.hpp
@@ -6,7 +6,7 @@ namespace vol::win {
 
 struct Status {
   HRESULT hr;
-  inline bool is_ok() const { return SUCCEED(hr); }
+  inline bool is_ok() const { return hr == S_OK; }
 };
 
 template <typename T>

--- a/core/windows/include/volume/core/windows/status.hpp
+++ b/core/windows/include/volume/core/windows/status.hpp
@@ -6,7 +6,7 @@ namespace vol::win {
 
 struct Status {
   HRESULT hr;
-  bool is_ok() const { return SUCCEEDED(hr); }
+  inline bool is_ok() const { return SUCCEED(hr); }
 };
 
 template <typename T>

--- a/core/windows/src/com.cpp
+++ b/core/windows/src/com.cpp
@@ -1,0 +1,25 @@
+#include <Objbase.h>
+#include <mmdeviceapi.h>
+
+#include <volume/core/windows/com.hpp>
+
+namespace vol::win {
+
+Com::~Com() {
+  if (is_ok()) CoUninitialize();
+}
+
+DeviceEnumerator Com::create_device_enumerator() {
+  DeviceEnumerator res;
+  res.hr = CoCreateInstance(__uuidof(MMDeviceEnumerator), NULL, CLSCTX_ALL,
+                            __uuidof(IMMDeviceEnumerator), (void**)&res.p);
+  return res;
+}
+
+Com com_init() {
+  Com res;
+  res.hr = CoInitialize(NULL);
+  return res;
+}
+
+}  // namespace vol::win

--- a/core/windows/src/device.cpp
+++ b/core/windows/src/device.cpp
@@ -1,0 +1,9 @@
+#include <volume/core/windows/device.hpp>
+
+namespace vol::win {
+
+Device::~Device() {
+  if (is_ok()) p->Release();
+}
+
+}  // namespace vol::win

--- a/core/windows/src/device_collection.cpp
+++ b/core/windows/src/device_collection.cpp
@@ -1,0 +1,21 @@
+#include <volume/core/windows/device_collection.hpp>
+
+namespace vol::win {
+
+DeviceCollection::~DeviceCollection() {
+  if (is_ok()) p->Release();
+}
+
+StatusOf<UINT> DeviceCollection::count() {
+  StatusOf<UINT> res;
+  res.hr = p->GetCount(&res.val);
+  return res;
+}
+
+Device DeviceCollection::get(UINT id) {
+  Device res;
+  res.hr = p->Item(id, &res.p);
+  return res;
+}
+
+}  // namespace vol::win

--- a/core/windows/src/device_enumerator.cpp
+++ b/core/windows/src/device_enumerator.cpp
@@ -1,0 +1,21 @@
+#include <volume/core/windows/device_enumerator.hpp>
+
+namespace vol::win {
+
+DeviceEnumerator::~DeviceEnumerator() {
+  if (is_ok()) p->Release();
+}
+
+DeviceCollection DeviceEnumerator::enumerate_input_devices() {
+  DeviceCollection res;
+  res.hr = p->EnumAudioEndpoints(eCapture, DEVICE_STATE_ACTIVE, &res.p);
+  return res;
+}
+
+DeviceCollection DeviceEnumerator::enumerate_output_devices() {
+  DeviceCollection res;
+  res.hr = p->EnumAudioEndpoints(eRender, DEVICE_STATE_ACTIVE, &res.p);
+  return res;
+}
+
+}  // namespace vol::win


### PR DESCRIPTION
- compile `volume_core_windows` into a static library by separate definition of it's functions into `src` directory.
  - make the other functions to be inline.
- modify header file for `HRESULT` to use `Winerror.h`.