### PR TITLE
Show Message of `vol::win::Status`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,12 @@ cpmaddpackage(
   GIT_TAG ab4b3c1
   OPTIONS "BUILD_TESTING OFF")
 
+if(BUILD_TESTING)
+  enable_testing()
+  cpmaddpackage("gh:catchorg/Catch2@3.2.0")
+  include("${Catch2_SOURCE_DIR}/extras/Catch.cmake")
+endif()
+
 if(WIN32)
   set(WINDOWS_SRCS src/device_windows.cpp)
 endif()
@@ -33,11 +39,6 @@ if(WIN32)
 endif()
 
 if(BUILD_TESTING)
-  enable_testing()
-
-  cpmaddpackage("gh:catchorg/Catch2@3.2.0")
-  include("${Catch2_SOURCE_DIR}/extras/Catch.cmake")
-
   add_executable(volume_test test/device_test.cpp)
   target_link_libraries(volume_test PRIVATE volume Catch2::Catch2WithMain)
   catch_discover_tests(volume_test)

--- a/core/windows/CMakeLists.txt
+++ b/core/windows/CMakeLists.txt
@@ -1,3 +1,10 @@
 add_library(volume_core_windows STATIC src/com.cpp src/device_collection.cpp src/device_enumerator.cpp src/device.cpp
                                        src/status.cpp)
 target_include_directories(volume_core_windows PUBLIC include)
+
+
+if(BUILD_TESTING)
+  add_executable(volume_core_windows_test test/status_test.cpp)
+  target_link_libraries(volume_core_windows_test PRIVATE volume Catch2::Catch2WithMain)
+  catch_discover_tests(volume_core_windows_test)
+endif()

--- a/core/windows/CMakeLists.txt
+++ b/core/windows/CMakeLists.txt
@@ -2,7 +2,6 @@ add_library(volume_core_windows STATIC src/com.cpp src/device_collection.cpp src
                                        src/status.cpp)
 target_include_directories(volume_core_windows PUBLIC include)
 
-
 if(BUILD_TESTING)
   add_executable(volume_core_windows_test test/status_test.cpp)
   target_link_libraries(volume_core_windows_test PRIVATE volume Catch2::Catch2WithMain)

--- a/core/windows/CMakeLists.txt
+++ b/core/windows/CMakeLists.txt
@@ -1,2 +1,3 @@
-add_library(volume_core_windows STATIC src/com.cpp src/device_collection.cpp src/device_enumerator.cpp src/device.cpp)
+add_library(volume_core_windows STATIC src/com.cpp src/device_collection.cpp src/device_enumerator.cpp src/device.cpp
+                                       src/status.cpp)
 target_include_directories(volume_core_windows PUBLIC include)

--- a/core/windows/include/volume/core/windows/status.hpp
+++ b/core/windows/include/volume/core/windows/status.hpp
@@ -2,11 +2,14 @@
 
 #include <Winerror.h>
 
+#include <string>
+
 namespace vol::win {
 
 struct Status {
   HRESULT hr;
   inline bool is_ok() const { return hr == S_OK; }
+  std::string message() const;
 };
 
 template <typename T>

--- a/core/windows/src/status.cpp
+++ b/core/windows/src/status.cpp
@@ -1,0 +1,9 @@
+#include <comdef.h>
+
+#include <volume/core/windows/status.hpp>
+
+namespace vol::win {
+
+std::string Status::message() const { return _com_error(hr).ErrorMessage(); }
+
+}  // namespace vol::win

--- a/core/windows/test/status_test.cpp
+++ b/core/windows/test/status_test.cpp
@@ -12,3 +12,15 @@ TEST_CASE("check Windows core's status") {
     CHECK_FALSE(status.is_ok());
   }
 }
+
+TEST_CASE("check Windows core's status message") {
+  vol::win::Status status;
+  SECTION("ok status") {
+    status.hr = S_OK;
+    CHECK(status.message() == std::string("The operation completed successfully."));
+  }
+  SECTION("error status") {
+    status.hr = E_FAIL;
+    CHECK(status.message() == std::string("Unspecified error"));
+  }
+}

--- a/core/windows/test/status_test.cpp
+++ b/core/windows/test/status_test.cpp
@@ -1,0 +1,14 @@
+#include <catch2/catch_test_macros.hpp>
+#include <volume/core/windows/status.hpp>
+
+TEST_CASE("check Windows core's status") {
+  vol::win::Status status;
+  SECTION("ok status") {
+    status.hr = S_OK;
+    CHECK(status.is_ok());
+  }
+  SECTION("error status") {
+    status.hr = E_UNEXPECTED;
+    CHECK_FALSE(status.is_ok());
+  }
+}

--- a/src/device_windows.cpp
+++ b/src/device_windows.cpp
@@ -9,7 +9,7 @@ namespace {
 res::ResultOf<Devices> to_devices(win::DeviceCollection& win_devices) {
   auto count = win_devices.count();
   if (!count.is_ok()) {
-    return res::Err("failed to count devices");
+    return res::ErrStream() << "failed to count devices: " << count.message();
   }
   Devices devices;
   for (UINT i = 0; i < count.val; ++i) {
@@ -25,15 +25,17 @@ res::ResultOf<Devices> to_devices(win::DeviceCollection& win_devices) {
 res::ResultOf<Devices> list_input_devices() {
   auto win_com = win::com_init();
   if (!win_com.is_ok()) {
-    return res::Err("failed to initialize COM");
+    return res::ErrStream() << "failed to initialize COM: " << win_com.message();
   }
   auto win_enumerator = win_com.create_device_enumerator();
   if (!win_enumerator.is_ok()) {
-    return res::Err("failed to create a device enumerator");
+    return res::ErrStream() << "failed to create a device enumerator: "
+                            << win_enumerator.message();
   }
   auto win_devices = win_enumerator.enumerate_input_devices();
   if (!win_devices.is_ok()) {
-    return res::Err("failed to enumerate input devices");
+    return res::ErrStream() << "failed to enumerate input devices: "
+                            << win_devices.message();
   }
   return to_devices(win_devices);
 }
@@ -41,15 +43,17 @@ res::ResultOf<Devices> list_input_devices() {
 res::ResultOf<Devices> list_output_devices() {
   auto win_com = win::com_init();
   if (!win_com.is_ok()) {
-    return res::Err("failed to initialize COM");
+    return res::ErrStream() << "failed to initialize COM: " << win_com.message();
   }
   auto win_enumerator = win_com.create_device_enumerator();
   if (!win_enumerator.is_ok()) {
-    return res::Err("failed to create a device enumerator");
+    return res::ErrStream() << "failed to create a device enumerator: "
+                            << win_enumerator.message();
   }
   auto win_devices = win_enumerator.enumerate_output_devices();
   if (!win_devices.is_ok()) {
-    return res::Err("failed to enumerate output devices");
+    return res::ErrStream() << "failed to enumerate output devices: "
+                            << win_devices.message();
   }
   return to_devices(win_devices);
 }


### PR DESCRIPTION
- Add `message()` function in `vol::win::Status` to print error message.
- Add test for `vol::win::Status`.
- Return error message if core Windows's function return error.