### PR TITLE
Setup Audio Devices in GitHub Workflows

### DIFF
--- a/.cmake-format
+++ b/.cmake-format
@@ -10,6 +10,11 @@
         "GIT_TAG": "*",
         "OPTIONS": "*"
       }
+    },
+    "set": {
+      "kwargs": {
+        "CACHE": "1+"
+      }
     }
   }
 }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3.3.0
 
+      - name: Configure CMake
+        run: cmake . -B build -DBUILD_TESTING=ON
+
+      - name: Build targets
+        run: cmake --build build
+
+      - name: Run tests
+        run: ctest --test-dir build --output-on-failure
+
       - name: Checkout CI sound helpers repository
         uses: actions/checkout@v3.3.0
         with:
@@ -20,13 +29,13 @@ jobs:
           net start audiosrv
           powershell sound/windows/setup_sound.ps1
 
-      - name: Configure CMake
-        run: cmake . -B build -DBUILD_TESTING=ON
+      - name: Reconfigure CMake
+        run: cmake build -DTESTING_INPUTS_COUNT=1 -DTESTING_OUTPUTS_COUNT=1
 
-      - name: Build targets
+      - name: Rebuild targets
         run: cmake --build build
 
-      - name: Run tests
+      - name: Rerun tests
         run: ctest --test-dir build --output-on-failure
 
   check-warning:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,8 @@ jobs:
           repository: LABSN/sound-ci-helpers
           path: sound
 
-      - name: Setup sound device
-        run: sound/auto.sh
+      - name: Setup sound devices
+        run: powershell sound/windows/setup_sound.ps1
 
       - name: Configure CMake
         run: cmake . -B build -DBUILD_TESTING=ON

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
         run: cmake --build build
 
       - name: Run tests
-        run: ctest --test-dir build --verbose
+        run: ctest --test-dir build --output-on-failure
 
   check-warning:
     runs-on: windows-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3.3.0
 
+      - name: Checkout CI sound helpers repository
+        uses: actions/checkout@v3.3.0
+        with:
+          repository: LABSN/sound-ci-helpers
+          path: sound
+
+      - name: Setup sound device
+        run: sound/auto.sh
+
       - name: Configure CMake
         run: cmake . -B build -DBUILD_TESTING=ON
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,9 @@ jobs:
           path: sound
 
       - name: Setup sound devices
-        run: powershell sound/windows/setup_sound.ps1
+        run: |
+          net start audiosrv
+          powershell sound/windows/setup_sound.ps1
 
       - name: Configure CMake
         run: cmake . -B build -DBUILD_TESTING=ON

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@v3.3.0
 
       - name: Configure CMake
-        run: cmake . -B build -DCMAKE_CXX_FLAGS='/WX' -DBUILD_TESTING=ON
+        run: cmake . -B build -DCMAKE_CXX_FLAGS='/WX' -DBUILD_TESTING=ON -DTESTING_INPUTS_COUNT=1 -DTESTING_OUTPUTS_COUNT=1
 
       - name: Build targets
         run: cmake --build build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,8 @@ else()
 endif()
 
 option(BUILD_EXAMPLE "build the examples" OFF)
-set(TESTING_INPUTS_COUNT 0 CACHE STRING "count of input devices that is available for testing")
-set(TESTING_OUTPUTS_COUNT 0 CACHE STRING "count of output devices that is available for testing")
+set(TESTING_INPUTS_COUNT -1 CACHE STRING "count of input devices that is available for testing")
+set(TESTING_OUTPUTS_COUNT -1 CACHE STRING "count of output devices that is available for testing")
 
 include(cmake/CPM.cmake)
 cpmaddpackage("gh:TheLartians/Format.cmake@1.7.3")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,8 @@ else()
 endif()
 
 option(BUILD_EXAMPLE "build the examples" OFF)
+set(TESTING_INPUTS_COUNT 0 CACHE STRING "count of input devices that is available for testing")
+set(TESTING_OUTPUTS_COUNT 0 CACHE STRING "count of output devices that is available for testing")
 
 include(cmake/CPM.cmake)
 cpmaddpackage("gh:TheLartians/Format.cmake@1.7.3")
@@ -42,6 +44,9 @@ endif()
 if(BUILD_TESTING)
   add_executable(volume_test test/device_test.cpp)
   target_link_libraries(volume_test PRIVATE volume Catch2::Catch2WithMain)
+  target_compile_definitions(
+    volume_test PRIVATE TESTING_INPUTS_COUNT=${TESTING_INPUTS_COUNT} TESTING_OUTPUTS_COUNT=${TESTING_OUTPUTS_COUNT}
+  )
   catch_discover_tests(volume_test)
 endif()
 

--- a/test/device_test.cpp
+++ b/test/device_test.cpp
@@ -4,11 +4,11 @@
 TEST_CASE("list input devices") {
   const auto res = vol::list_input_devices();
   if (res.is_err()) FAIL(res.unwrap_err());
-  REQUIRE(res.unwrap().size() > 0);
+  REQUIRE(res.unwrap().size() == TESTING_INPUTS_COUNT);
 }
 
 TEST_CASE("list output devices") {
   const auto res = vol::list_output_devices();
   if (res.is_err()) FAIL(res.unwrap_err());
-  REQUIRE(res.unwrap().size() > 0);
+  REQUIRE(res.unwrap().size() == TESTING_OUTPUTS_COUNT);
 }

--- a/test/device_test.cpp
+++ b/test/device_test.cpp
@@ -4,9 +4,11 @@
 TEST_CASE("list input devices") {
   const auto res = vol::list_input_devices();
   if (res.is_err()) FAIL(res.unwrap_err());
+  REQUIRE(res.unwrap().size() > 0);
 }
 
 TEST_CASE("list output devices") {
   const auto res = vol::list_output_devices();
   if (res.is_err()) FAIL(res.unwrap_err());
+  REQUIRE(res.unwrap().size() > 0);
 }

--- a/test/device_test.cpp
+++ b/test/device_test.cpp
@@ -4,11 +4,15 @@
 TEST_CASE("list input devices") {
   const auto res = vol::list_input_devices();
   if (res.is_err()) FAIL(res.unwrap_err());
-  REQUIRE(res.unwrap().size() == TESTING_INPUTS_COUNT);
+  if constexpr (TESTING_INPUTS_COUNT >= 0) {
+    REQUIRE(res.unwrap().size() == TESTING_INPUTS_COUNT);
+  }
 }
 
 TEST_CASE("list output devices") {
   const auto res = vol::list_output_devices();
   if (res.is_err()) FAIL(res.unwrap_err());
-  REQUIRE(res.unwrap().size() == TESTING_OUTPUTS_COUNT);
+  if constexpr (TESTING_OUTPUTS_COUNT >= 0) {
+    REQUIRE(res.unwrap().size() == TESTING_OUTPUTS_COUNT);
+  }
 }


### PR DESCRIPTION
- Use [sound-ci-helpers](https://github.com/LABSN/sound-ci-helpers) to setup audio devices in the GitHub Workflows.
- Add `TESTING_INPUTS_COUNT` and `TESTING_OUTPUTS_COUNT` options in CMake to determine if it's possible to test for audio devices count.
- Make volume test check if list devices size is equal to `TESTING_INPUTS_COUNT` and `TESTING_OUTPUTS_COUNT` options.
- Make `unit-tests` job in the `test.yml` workflow to run tests twice. One without virtual audio devices and one with them.