### PR TITLE
Bump CPM.cmake to v0.38.1

### DIFF
--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -1,4 +1,4 @@
-set(CPM_DOWNLOAD_VERSION 0.36.0)
+set(CPM_DOWNLOAD_VERSION 0.38.1)
 
 if(CPM_SOURCE_CACHE)
   set(CPM_DOWNLOAD_LOCATION "${CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
@@ -10,10 +10,23 @@ endif()
 
 # Expand relative path. This is important if the provided path contains a tilde (~)
 get_filename_component(CPM_DOWNLOAD_LOCATION ${CPM_DOWNLOAD_LOCATION} ABSOLUTE)
-if(NOT (EXISTS ${CPM_DOWNLOAD_LOCATION}))
+
+function(download_cpm)
   message(STATUS "Downloading CPM.cmake to ${CPM_DOWNLOAD_LOCATION}")
-  set(CPM_DOWNLOAD_URL https://github.com/cpm-cmake/CPM.cmake/releases/download)
-  file(DOWNLOAD ${CPM_DOWNLOAD_URL}/v${CPM_DOWNLOAD_VERSION}/CPM.cmake ${CPM_DOWNLOAD_LOCATION})
+  file(DOWNLOAD https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake
+       ${CPM_DOWNLOAD_LOCATION}
+  )
+endfunction()
+
+if(NOT (EXISTS ${CPM_DOWNLOAD_LOCATION}))
+  download_cpm()
+else()
+  # resume download if it previously failed
+  file(READ ${CPM_DOWNLOAD_LOCATION} check)
+  if("${check}" STREQUAL "")
+    download_cpm()
+  endif()
+  unset(check)
 endif()
 
 include(${CPM_DOWNLOAD_LOCATION})


### PR DESCRIPTION
Bump [CPM.cmake](https://github.com/cpm-cmake/CPM.cmake) to the [latest version (v0.38.1)](https://github.com/cpm-cmake/CPM.cmake/releases/tag/v0.38.1). This PR also update the get CPM script (`cmake/CPM.cmake`).