### PR TITLE
Revert Update of Format.cmake to Support Auto Installation of cmake-format

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4.1.1
 
+      - name: Install cmakelang
+        uses: threeal/pipx-install-action@v1.0.0
+        with:
+          packages: cmakelang
+
       - name: Configure and build the project
         uses: threeal/cmake-action@v1.3.0
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ include(cmake/CPM.cmake)
 cpmaddpackage("gh:threeal/result@0.1.0")
 
 if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
-  cpmaddpackage("gh:threeal/Format.cmake#auto-install-cmake-format")
+  cpmaddpackage(gh:TheLartians/Format.cmake@1.8.1)
 
   if(BUILD_TESTING)
     enable_testing()


### PR DESCRIPTION
This pull request resolves #37 basically by reverting changes introduced in #27.