### PR TITLE
Remove `latest` Branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,8 @@ name: build
 on:
   workflow_dispatch:
   pull_request:
-    branches: ['*', '!latest']
   push:
-    branches: [latest, main]
+    branches: [main]
 jobs:
   release:
     runs-on: windows-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,8 @@ name: test
 on:
   workflow_dispatch:
   pull_request:
-    branches: ['*', '!latest']
   push:
-    branches: [latest, main]
+    branches: [main]
 jobs:
   unit-tests:
     runs-on: windows-latest


### PR DESCRIPTION
This pull request resolves #39 by removing the `latest` branch from triggering workflow run.