### PR TITLE
Utilize `PROJECT_IS_TOP_LEVEL` Variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.21)
 project(volume)
 
 set(CMAKE_CXX_STANDARD 17)
@@ -16,7 +16,7 @@ set(TESTING_OUTPUTS_COUNT -1 CACHE STRING "count of output devices that is avail
 include(cmake/CPM.cmake)
 cpmaddpackage("gh:threeal/result@0.1.0")
 
-if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+if(PROJECT_IS_TOP_LEVEL)
   cpmaddpackage(gh:TheLartians/Format.cmake@1.8.1)
 
   if(BUILD_TESTING)
@@ -39,7 +39,7 @@ if(WIN32)
   target_link_libraries(volume PUBLIC volume_core_windows)
 endif()
 
-if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+if(PROJECT_IS_TOP_LEVEL)
   if(BUILD_TESTING)
     add_executable(volume_test test/device_test.cpp)
     target_link_libraries(volume_test PRIVATE volume Catch2::Catch2WithMain)

--- a/core/windows/CMakeLists.txt
+++ b/core/windows/CMakeLists.txt
@@ -8,7 +8,7 @@ add_library(
 )
 target_include_directories(volume_core_windows PUBLIC include)
 
-if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR AND BUILD_TESTING)
+if(PROJECT_IS_TOP_LEVEL AND BUILD_TESTING)
   add_executable(volume_core_windows_test test/status_test.cpp)
   target_link_libraries(volume_core_windows_test PRIVATE volume Catch2::Catch2WithMain)
   catch_discover_tests(volume_core_windows_test)


### PR DESCRIPTION
This pull request resolves #52 by utilizing the `PROJECT_IS_TOP_LEVEL` variable, replacing the `CMAKE_CURRENT_SOURCE_DIR` and `CMAKE_SOURCE_DIR` variables comparison. This change also bumps the minimum CMake version to 3.21.