### PR TITLE
Add Option to Enable Test Targets

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Configure, build, and test the project
         uses: threeal/cmake-action@v1.3.0
         with:
-          options: BUILD_TESTING=ON
+          options: VOLUME_ENABLE_TESTS=ON
           run-test: true
 
       - name: Checkout the CI sound helpers repository
@@ -44,7 +44,7 @@ jobs:
         uses: threeal/cmake-action@v1.3.0
         with:
           cxx-flags: /WX
-          options: BUILD_TESTING=ON TESTING_INPUTS_COUNT=1 TESTING_OUTPUTS_COUNT=1
+          options: VOLUME_ENABLE_TESTS=ON TESTING_INPUTS_COUNT=1 TESTING_OUTPUTS_COUNT=1
           run-build: true
 
   check-formatting:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.21)
 project(volume)
 
+option(VOLUME_ENABLE_TESTS "Enable test targets.")
+
 set(CMAKE_CXX_STANDARD 17)
 
 if(MSVC)
@@ -19,7 +21,7 @@ cpmaddpackage("gh:threeal/result@0.1.0")
 if(PROJECT_IS_TOP_LEVEL)
   cpmaddpackage(gh:TheLartians/Format.cmake@1.8.1)
 
-  if(BUILD_TESTING)
+  if(VOLUME_ENABLE_TESTS)
     enable_testing()
     cpmaddpackage(gh:catchorg/Catch2@3.6.0)
     include("${Catch2_SOURCE_DIR}/extras/Catch.cmake")
@@ -40,7 +42,7 @@ if(WIN32)
 endif()
 
 if(PROJECT_IS_TOP_LEVEL)
-  if(BUILD_TESTING)
+  if(VOLUME_ENABLE_TESTS)
     add_executable(volume_test test/device_test.cpp)
     target_link_libraries(volume_test PRIVATE volume Catch2::Catch2WithMain)
     target_compile_definitions(

--- a/core/windows/CMakeLists.txt
+++ b/core/windows/CMakeLists.txt
@@ -8,7 +8,7 @@ add_library(
 )
 target_include_directories(volume_core_windows PUBLIC include)
 
-if(PROJECT_IS_TOP_LEVEL AND BUILD_TESTING)
+if(PROJECT_IS_TOP_LEVEL AND VOLUME_ENABLE_TESTS)
   add_executable(volume_core_windows_test test/status_test.cpp)
   target_link_libraries(volume_core_windows_test PRIVATE volume Catch2::Catch2WithMain)
   catch_discover_tests(volume_core_windows_test)


### PR DESCRIPTION
This pull request resolves #54 by adding a `VOLUME_ENABLE_TESTS` option to enable test targets in the project, replacing the `BUILD_TESTING` variable.