### PR TITLE
Bump Catch2 to Version 3.7.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ if(PROJECT_IS_TOP_LEVEL)
 
   if(VOLUME_ENABLE_TESTS)
     enable_testing()
-    cpmaddpackage(gh:catchorg/Catch2@3.6.0)
+    cpmaddpackage(gh:catchorg/Catch2@3.7.0)
     include("${Catch2_SOURCE_DIR}/extras/Catch.cmake")
   endif()
 endif()


### PR DESCRIPTION
This pull request simply bumps Catch2 to version [3.7.0](https://github.com/catchorg/Catch2/releases/tag/v3.7.0).