### PR TITLE
Specify Runner OS Version in Workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
     branches: [main]
 jobs:
   release:
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4.1.7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
     branches: [main]
 jobs:
   unit-tests:
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4.1.7
@@ -41,7 +41,7 @@ jobs:
         uses: threeal/ctest-action@v1.1.0
 
   check-warning:
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4.1.7
@@ -56,7 +56,7 @@ jobs:
             TESTING_OUTPUTS_COUNT=1
 
   check-formatting:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4.1.7


### PR DESCRIPTION
This pull request resolves #61 by manually specifying the runner OS version to be used in workflows, replacing the default latest version.